### PR TITLE
Link name to React Query in README fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Hooks for virtualizing scrollable elements in React
   <img alt="" src="https://img.shields.io/twitter/follow/tannerlinsley.svg?style=social&label=Follow" />
 </a>
 
-Enjoy this library? Try them all! [React Table](https://github.com/tannerlinsley/react-table), [React Virtual](https://github.com/tannerlinsley/react-query), [React Form](https://github.com/tannerlinsley/react-form),
+Enjoy this library? Try them all! [React Table](https://github.com/tannerlinsley/react-table), [React Query](https://github.com/tannerlinsley/react-query), [React Form](https://github.com/tannerlinsley/react-form),
 [React Charts](https://github.com/tannerlinsley/react-charts)
 
 ## Quick Features


### PR DESCRIPTION
Sorry for this tiny change, but I just happen to see if while reading the README.