### PR TITLE
docs: fix incorrect variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ function RowVirtualizerFixed() {
 
 ```js
 const {
-  items: [
+  virtualItems: [
     { index, start, size, end, measureRef },
     /* ... */
   ],
@@ -307,7 +307,7 @@ const {
 
 ### Returns
 
-- `items: Array<item>`
+- `virtualItems: Array<item>`
   - `item: Object`
     - `index: Integer`
       - The index of the item


### PR DESCRIPTION
Hi there,

I noticed that `items` is no longer returned from the hook in the latest release, so I changed it to `virtualItems` in the docs. Would be great if you could also update the version of `react-virtual` used in the Codesandbox!

Kind regards,
Hampus Kraft.