### PR TITLE
chore(actions): add cache to NPM dependencies on GitHub actions

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -3,43 +3,41 @@ name: react-virtual tests
 on:
   push:
     branches:
-      - 'master'
+      - "master"
+      - "next"
+      - "1.x"
   pull_request:
 
 jobs:
   test:
-    name: 'node ${{ matrix.node }} ${{ matrix.os }} '
-    runs-on: '${{ matrix.os }}'
+    name: "Node ${{ matrix.node }}"
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node: [12, 10]
+        node: [10, 12, 14]
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - run: npm i -g yarn
-      - run: yarn --frozen-lockfile
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
       - run: yarn test:ci
 
   publish-module:
-    name: 'Publish Module to NPM'
+    name: "Publish Module to NPM"
     needs: test
-    if: github.ref == 'refs/heads/master' #publish only when merged in master, not on PR
+    # publish only when merged in master on original repo, not on PR
+    if: github.repository == 'tannerlinsley/react-virtual' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/1.x')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm i -g yarn
-      - run: yarn --frozen-lockfile
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
       - run: npx semantic-release@17
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-virtual",
-  "version": "0.0.0",
+  "version": "1.0.0-semantic-release",
   "description": "Hooks for virtualizing scrollable elements in React",
   "author": "tannerlinsley",
   "license": "MIT",
@@ -20,8 +20,6 @@
     "start": "rollup -c -w",
     "prepare": "yarn build",
     "prepublishOnly": "yarn test:ci && yarn formatReadme",
-    "release": "yarn publish",
-    "releaseNext": "yarn publish --tag next",
     "format": "prettier {src,src/**,example/src,example/src/**}/*.{md,js,jsx,tsx} --write",
     "formatReadme": "yarn doctoc",
     "doctoc": "npx doctoc --maxlevel 2 README.md",
@@ -29,6 +27,16 @@
     "stats": "open ./stats.html",
     "postinstall": "node ./scripts/postinstall.js || exit 0",
     "dtslint": "dtslint types"
+  },
+  "release": {
+    "branches": [
+      "1.x",
+      "master",
+      {
+        "name": "next",
+        "prerelease": true
+      }
+    ]
   },
   "files": [
     "dist",


### PR DESCRIPTION
This uses [bahmutov/npm-install](https://github.com/bahmutov/npm-install) to install NPM dependencies with caching without any configuration.