### PR TITLE
fix: return empty list when size is 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,9 @@ export function useVirtual({
 
   const virtualItems = React.useMemo(() => {
     const virtualItems = []
+    const end = Math.min(range.end, measurements.length - 1)
 
-    for (let i = range.start; i <= range.end; i++) {
+    for (let i = range.start; i <= end; i++) {
       const measurement = measurements[i]
 
       const item = {


### PR DESCRIPTION
The `range` state doesn't update in response of changes to `size` until the layout effect is applied. I don't want to update state within the render function, so adding a guard seems like the best approach.

Fixes #52
Might fix #49