### PR TITLE
fix: don't do onScroll when there is no element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ export function useVirtual({
     const element = parentRef.current
 
     const onScroll = () => {
+      if (!element) return
       const scrollOffset = element[scrollKey]
       latestRef.current.scrollOffset = scrollOffset
       setRange(prevRange => calculateRange(latestRef.current, prevRange))


### PR DESCRIPTION
Probably should have tests for this, but I thought I'd throw this together to help push #64 along a bit.

Closes #64