### PR TITLE
fix: don't attach event listeners when there's no element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,9 +69,9 @@ export function useVirtual({
 
   useIsomorphicLayoutEffect(() => {
     const element = parentRef.current
+    if (!element) { return }
 
     const onScroll = () => {
-      if (!element) return
       const scrollOffset = element[scrollKey]
       latestRef.current.scrollOffset = scrollOffset
       setRange(prevRange => calculateRange(latestRef.current, prevRange))


### PR DESCRIPTION
Fixes #68