### PR TITLE
fix: typings for optional useObserver parameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,13 @@ declare function useVirtual<T>(options: {
   ) => void
   paddingStart?: number
   paddingEnd?: number
+  useObserver?: (
+    ref: React.RefObject<T>
+  ) => {
+    width: number
+    height: number
+    [key: string]: any
+  }
 }): {
   virtualItems: VirtualItem[]
   totalSize: number


### PR DESCRIPTION
I missed `react-virtual` has typings in the previous PR, so let me please fix it with this one.