### PR TITLE
chore: allow react v17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts-toolbelt": "^6.4.2"
   },
   "peerDependencies": {
-    "react": "^16.6.3"
+    "react": "^16.6.3 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",


### PR DESCRIPTION
### Why

This pull request to allow react 17 as peer dependency. This version of react should ([in theory](https://reactjs.org/blog/2020/10/20/react-v17.html#other-breaking-changes)) not break anything. At work we are currently on react 17, we've had no issue related to it and we are on the latest version of [react-virtual](https://github.com/tannerlinsley/react-virtual).
