### PR TITLE
feat: support caching dynamic measurements by unique key

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ const {
  - `scrollOffsetFn: Function() => number`
    - Optional
    - This function, if passed, is called on scroll to get the scroll offest rather than using `parentRef`'s `width` or `height`
+- `keyExtractor: Function(index) => String | Integer`
+  - Optional
+  - This function receives the index of each item and should return the item's unique ID.
+  - This function should be passed whenever dynamic measurement rendering is enabled and the size or order of items in the list changes.
 
 ### Returns
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,10 +49,7 @@ export function useVirtual({
 
   const [measuredCache, setMeasuredCache] = React.useState({})
 
-  const measure = React.useCallback(
-    () => setMeasuredCache({}),
-    []
-  )
+  const measure = React.useCallback(() => setMeasuredCache({}), [])
 
   const measurements = React.useMemo(() => {
     const measurements = []
@@ -80,10 +77,14 @@ export function useVirtual({
 
   const element = onScrollElement ? onScrollElement.current : parentRef.current
   useIsomorphicLayoutEffect(() => {
-    if (!element) { return }
+    if (!element) {
+      return
+    }
 
     const onScroll = () => {
-      const scrollOffset = scrollOffsetFn ? scrollOffsetFn() : element[scrollKey]
+      const scrollOffset = scrollOffsetFn
+        ? scrollOffsetFn()
+        : element[scrollKey]
       latestRef.current.scrollOffset = scrollOffset
       setRange(prevRange => calculateRange(latestRef.current, prevRange))
     }
@@ -134,7 +135,14 @@ export function useVirtual({
     }
 
     return virtualItems
-  }, [range.start, range.end, measurements, sizeKey, defaultScrollToFn, keyExtractor])
+  }, [
+    range.start,
+    range.end,
+    measurements,
+    sizeKey,
+    defaultScrollToFn,
+    keyExtractor,
+  ])
 
   const mountedRef = React.useRef()
 
@@ -194,8 +202,8 @@ export function useVirtual({
         align === 'center'
           ? measurement.start + measurement.size / 2
           : align === 'end'
-            ? measurement.end
-            : measurement.start
+          ? measurement.end
+          : measurement.start
 
       scrollToOffset(toOffset, { align, ...rest })
     },
@@ -226,19 +234,20 @@ export function useVirtual({
   }
 }
 
-function calculateRange({
-  overscan,
-  measurements,
-  outerSize,
-  scrollOffset,
-}, prevRange) {
+function calculateRange(
+  { overscan, measurements, outerSize, scrollOffset },
+  prevRange
+) {
   const total = measurements.length
   let start = total - 1
   while (start > 0 && measurements[start].end >= scrollOffset) {
     start -= 1
   }
   let end = 0
-  while (end < total - 1 && measurements[end].start <= scrollOffset + outerSize) {
+  while (
+    end < total - 1 &&
+    measurements[end].start <= scrollOffset + outerSize
+  ) {
     end += 1
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ declare function useVirtual<T>(options: {
     height: number
     [key: string]: any
   }
+  keyExtractor?: (index: number) => number | string
 }): {
   virtualItems: VirtualItem[]
   totalSize: number


### PR DESCRIPTION
This PR introduces a `keyExtractor` option to the `useVirtual` hook, which allows dynamically measured items to be cached by unique ID. This will fix #83.

With these changes, the measure cache is no longer cleared when the list's `size` changes. I've been using these changes for an infinitely scrolling list of dynamically measured elements, and I haven't encountered any issues.

A few notes:
- I'm open to suggestions for a better name than `keyExtractor`. (I took the name `keyExtractor` from [React Native's `FlatList`](https://reactnative.dev/docs/flatlist#keyextractor).)
- There were a few lines in `src/index.js` that Prettier updated automatically.
- The only change I made to `types/index.d.ts` was to add `keyExtractor`…but this file's line endings were CRLF rather than LF. So, EditorConfig automatically converted all line endings to LF when I added my changes.