### PR TITLE
docs: add 'required' info to `estimateSize` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ const {
   - **Required**
   - The parent element whose inner-content is scrollable
 - `estimateSize: Function(index) => Integer`
+  - Defaults to `() => 50`
   - **Required**
   - **Must be memoized using `React.useCallback()`**
   - This function receives the index of each item and should return either:


### PR DESCRIPTION
Addresses #121 