### PR TITLE
feat: add isVisible to VirtualItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ const {
       - The ending measurement of the item
     - `measureRef: React.useRef | Function(el: DOMElement) => void 0`
       - The ref/function to place on the rendered element to enable dynamic measurement rendering
+    - `isVisible: Boolean`
+      - This value is true when item is visible in viewport
 - `totalSize: Integer`
   - The total size of the entire virtualizer
   - When using dynamic measurement refs, this number may change as items are measured after they are rendered.

--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ export function useVirtual({
 
       const item = {
         ...measurement,
+        isVisible: i >= range.start && i <= range.end,
         measureRef: el => {
           if (el) {
             const measuredSize = measureSizeRef.current(el, horizontal)

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -43,6 +43,7 @@ function List({
             <div
               key={virtualRow.index}
               ref={onRef ? onRef(virtualRow) : undefined}
+              data-is-visible={virtualRow.isVisible}
               style={{
                 position: 'absolute',
                 top: 0,
@@ -75,7 +76,14 @@ describe('useVirtual list', () => {
     render(<List {...props} />)
 
     expect(screen.queryByText('Row 0')).toBeInTheDocument()
-    expect(screen.queryByText('Row 4')).toBeInTheDocument()
+    expect(screen.queryByText('Row 3')).toHaveAttribute(
+      'data-is-visible',
+      'true'
+    )
+    expect(screen.queryByText('Row 4')).toHaveAttribute(
+      'data-is-visible',
+      'false'
+    )
     expect(screen.queryByText('Row 5')).not.toBeInTheDocument()
 
     expect(useVirtual).toHaveBeenCalledTimes(3)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,7 @@ export type VirtualItem = {
   end: number
   size: number
   measureRef: (el: HTMLElement | null) => void
+  isVisible: boolean
 }
 
 export interface Range {


### PR DESCRIPTION
This PR adds isVisible property toVirtualItem, making it easy to find what items are in viewport. 