### PR TITLE
fix: Page Title

### DIFF
--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -12,7 +12,7 @@ export const Nav = () => (
           <Link href="/" as="/">
             <a>
               <span className="sr-only">Home</span>
-              <img src={logoSrc} alt="React Charts" />
+              <img src={logoSrc} alt="React Virtual" />
             </a>
           </Link>
         </div>

--- a/docs/src/components/Seo.js
+++ b/docs/src/components/Seo.js
@@ -11,7 +11,7 @@ export const Seo = withRouter(
       {/* DEFAULT */}
 
       {title != undefined && (
-        <title key="title">{title} | React Charts | TanStack</title>
+        <title key="title">{title} | React Virtual | TanStack</title>
       )}
       {description != undefined && (
         <meta name="description" key="description" content={description} />


### PR DESCRIPTION
The title still says `React Charts` 😬 

This PR just changes that to `React Virtual`


![image](https://user-images.githubusercontent.com/8704336/128366787-1ee81c59-5b22-4df2-bb5b-ea9b5d7f083f.png)
