### PR TITLE
perf: reuse already measure items, include key into virtualItem

### DIFF
--- a/docs/src/pages/docs/api.md
+++ b/docs/src/pages/docs/api.md
@@ -8,7 +8,7 @@ title: API
 ```js
 const {
   virtualItems: [
-    { index, start, size, end, measureRef },
+    { key, index, start, size, end, measureRef },
     /* ... */
   ],
   totalSize,
@@ -83,6 +83,9 @@ const {
 
 - `virtualItems: Array<item>`
   - `item: Object`
+    - `key: String | Integer`
+      - The key of the item
+      - Defaults to `index`
     - `index: Integer`
       - The index of the item
     - `start: Integer`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,10 @@ interface ScrollToOptions {
 interface ScrollToOffsetOptions extends ScrollToOptions {}
 interface ScrollToIndexOptions extends ScrollToOptions {}
 
+type Key = number | string
+
 export type VirtualItem = {
+  key: Key
   index: number
   start: number
   end: number
@@ -43,7 +46,7 @@ declare function useVirtual<T>(options: {
     height: number
     [key: string]: any
   }
-  keyExtractor?: (index: number) => number | string
+  keyExtractor?: (index: number) => Key
   onScrollElement?: React.RefObject<HTMLElement>
   scrollOffsetFn?: (event?: Event) => number
   rangeExtractor?: (range: Range) => number[]


### PR DESCRIPTION
This PR adds small optimisation when creating measurements, as we don't need to rebuild the list from start, only from where item size changed. In addition added `key` value on virtualItem.

closes #120 