### PR TITLE
Made the row height dynamic in the dynamic example

### DIFF
--- a/examples/dynamic/src/index.js
+++ b/examples/dynamic/src/index.js
@@ -75,7 +75,7 @@ function RowVirtualizerDynamic({ rows }) {
                 top: 0,
                 left: 0,
                 width: "100%",
-                height: `${rows[virtualRow.index]}px`,
+                height: `${virtualRow.size}px`,
                 transform: `translateY(${virtualRow.start}px)`
               }}
             >


### PR DESCRIPTION
Previously the row height was not using the `virtualRow.measureRef` measurement

https://react-virtual.tanstack.com/examples/dynamic