### PR TITLE
Update the height and width values in examples

### DIFF
--- a/examples/dynamic/src/index.js
+++ b/examples/dynamic/src/index.js
@@ -75,7 +75,7 @@ function RowVirtualizerDynamic({ rows }) {
                 top: 0,
                 left: 0,
                 width: "100%",
-                height: `${rows[virtualRow.index]}px`,
+                height: `${virtualRow.size}px`,
                 transform: `translateY(${virtualRow.start}px)`
               }}
             >
@@ -127,7 +127,7 @@ function ColumnVirtualizerDynamic({ columns }) {
                 top: 0,
                 left: 0,
                 height: "100%",
-                width: `${columns[virtualColumn.index]}px`,
+                width: `${virtualColumn.size}px`,
                 transform: `translateX(${virtualColumn.start}px)`
               }}
             >
@@ -206,8 +206,8 @@ function GridVirtualizerDynamic({ rows, columns }) {
                       position: "absolute",
                       top: 0,
                       left: 0,
-                      width: `${columns[virtualColumn.index]}px`,
-                      height: `${rows[virtualRow.index]}px`,
+                      width: `${virtualColumn.size}px`,
+                      height: `${virtualRow.size}px`,
                       transform: `translateX(${virtualColumn.start}px) translateY(${virtualRow.start}px)`
                     }}
                   >

--- a/examples/infinite-scroll/src/index.js
+++ b/examples/infinite-scroll/src/index.js
@@ -76,7 +76,7 @@ function App() {
     }
 
     if (
-      lastItem.index === flatPosts.length - 1 &&
+      lastItem.index >= flatPosts.length - 1 &&
       canFetchMore &&
       !isFetchingMore
     ) {

--- a/examples/variable/src/index.js
+++ b/examples/variable/src/index.js
@@ -83,7 +83,7 @@ function RowVirtualizerVariable({ rows }) {
                 top: 0,
                 left: 0,
                 width: "100%",
-                height: `${virtualRow.size}px`,
+                height: `${rows[virtualRow.index]}px`,
                 transform: `translateY(${virtualRow.start}px)`
               }}
             >
@@ -136,7 +136,7 @@ function ColumnVirtualizerVariable({ columns }) {
                 top: 0,
                 left: 0,
                 height: "100%",
-                width: `${virtualColumn.size}px`,
+                width: `${columns[virtualColumn.index]}px`,
                 transform: `translateX(${virtualColumn.start}px)`
               }}
             >
@@ -203,8 +203,8 @@ function GridVirtualizerVariable({ rows, columns }) {
                     position: "absolute",
                     top: 0,
                     left: 0,
-                    width: `${virtualColumn.size}px`,
-                    height: `${virtualRow.size}px`,
+                    width: `${columns[virtualColumn.index]}px`,
+                    height: `${rows[virtualRow.index]}px`,
                     transform: `translateX(${virtualColumn.start}px) translateY(${virtualRow.start}px)`
                   }}
                 >


### PR DESCRIPTION
The dynamic examples were using heights from the generated data instead of the measurement. That is `${rows[virtualRow.index]}px` vs `${virtualRow.size}px`.

The variable example was doing the opposite (using `${virtualRow.size}px`) even though `ref={virtualRow.measureRef}` was never set in the variable example.

Also update the condition in infinite scroll (#161)