### PR TITLE
fix: Use `types/index.d.ts` for `types` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "index.js",
   "module": "dist/react-virtual.mjs",
-  "types": "types",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "test": "is-ci \"test:ci\" \"test:dev\"",


### PR DESCRIPTION
# Summary

Today, the `types` field is defined as follows:
https://github.com/tannerlinsley/react-virtual/blob/5508e19db343bcf02193a8c977f75f56e3d282cc/package.json#L17

While this ends up working during type-check, this isn't helping the auto-import suggestion in VSCode:

![image](https://user-images.githubusercontent.com/9748762/139414030-0138e6f0-096c-4d28-b0e0-14d750068bf0.png)

(I assume the shortest option from the same package is displayed, having `react-virtual/types` isn't ideal)

This is how it looks like after manually editing `node_modules/react-virtual/package.json` with this PR's changes (and restarting the TS server):

![image](https://user-images.githubusercontent.com/9748762/139414300-83b1114d-c746-4037-91d7-247e76123174.png)

---

Additionally, this helps partial matching for autocomplete.

Before:

![image](https://user-images.githubusercontent.com/9748762/139414509-d83e120a-cb08-49f1-9539-76c20290b2e1.png)

After:

![image](https://user-images.githubusercontent.com/9748762/139414573-11d9aa55-3686-4cbb-8de0-f7160f254574.png)
