### PR TITLE
Fixed Github Image Shield to show stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hooks for virtualizing scrollable elements in React
   <img alt="Join the community on Spectrum" src="https://withspectrum.github.io/badge/badge.svg" />
 </a>
 <a href="https://github.com/react-virtual/react-virtual" target="\_parent">
-  <img alt="" src="https://img.shields.io/github/stars/react-virtual/react-virtual.svg?style=social&label=Star" />
+  <img alt="" src="https://img.shields.io/github/stars/tannerlinsley/react-virtual.svg?style=social&label=Star" />
 </a>
 <a href="https://twitter.com/tannerlinsley" target="\_parent">
   <img alt="" src="https://img.shields.io/twitter/follow/tannerlinsley.svg?style=social&label=Follow" />


### PR DESCRIPTION
I've fixed the GitHub image shield for this repo in the README file which will now show the total number of stars that this repo has got.
Previously, it showed a ``repo not found`` error like the below screenshot,

![ok](https://user-images.githubusercontent.com/52027687/140634533-83e07e7e-64b6-49e4-bae6-bc0a505a7bfc.PNG)

